### PR TITLE
Wrong tag v0.14.0 should be v0.14.0-rc14

### DIFF
--- a/fetchhub-4/7-software-upgrade-v0.14.0.md
+++ b/fetchhub-4/7-software-upgrade-v0.14.0.md
@@ -50,7 +50,7 @@ If you already have an existing clone, place yourself in and:
 ```bash
 git fetch
 git clean -fd
-git checkout v0.14.0
+git checkout v0.14.0-rc14
 ```
 
 Now you can install the new `fetchd` version:


### PR DESCRIPTION
Hi,
Tag 
`git checkout v0.14.0`
Return =>
`error: pathspec 'v0.14.0' did not match any file(s) known to git`

Seem the right tag is 
=>
`git checkout v0.14.0-rc14`